### PR TITLE
[FIX] change api key name

### DIFF
--- a/neurosynth-compose-openapi.yml
+++ b/neurosynth-compose-openapi.yml
@@ -1591,7 +1591,7 @@ components:
     upload_key:
       type: apiKey
       in: header
-      name: compose_upload_key
+      name: Compose-Upload-Key
   parameters:
     nested:
       name: nested


### PR DESCRIPTION
api key names must be Camel-Case with hyphens, not snake_case