### PR TITLE
[ENH] version info

### DIFF
--- a/neurostore-openapi.yml
+++ b/neurostore-openapi.yml
@@ -209,6 +209,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/nested'
         - $ref: '#/components/parameters/studyset_owner'
+        - $ref: '#/components/parameters/flat'
     put:
       summary: PUT/update a study
       responses:
@@ -825,6 +826,8 @@ paths:
         - $ref: '#/components/parameters/publication'
         - $ref: '#/components/parameters/pmid'
         - $ref: '#/components/parameters/doi'
+        - $ref: '#/components/parameters/flat'
+        - $ref: '#/components/parameters/info'
       security:
         - JSON-Web-Token: []
         - {}
@@ -862,6 +865,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/base-study-return'
+      parameters:
+        - $ref: '#/components/parameters/flat'
+        - $ref: '#/components/parameters/info'
     put:
       summary: ''
       responses:
@@ -1953,6 +1959,23 @@ components:
       schema:
         type: string
       description: search for study with specific doi
+    flat:
+      name: flat
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - 'true'
+          - 'false'
+      description: 'do not return any embedded relationships. When set, it is incompatible with nested. '
+    info:
+      name: info
+      in: query
+      required: false
+      schema:
+        type: string
+      description: show additional for endpoint-object relationships without being fully nested. Incompatible with nested
   securitySchemes:
     JSON-Web-Token:
       type: http

--- a/neurostore-openapi.yml
+++ b/neurostore-openapi.yml
@@ -155,6 +155,7 @@ paths:
         - $ref: '#/components/parameters/level'
         - $ref: '#/components/parameters/pmid'
         - $ref: '#/components/parameters/doi'
+        - $ref: '#/components/parameters/flat'
       security:
         - JSON-Web-Token: []
         - {}


### PR DESCRIPTION
add version info on the base study endpoint so that the versions can be compared and sorted for choice.
also allow base-study and study endpoint to have a flat query parameter so that only results from that table are include and that other tables are not preloaded in the response